### PR TITLE
ajuste X-Erro ao Enviar WMS na JOB efetivar Automatica

### DIFF
--- a/FATURAMENTO/Ponto de Entrada/CASACHINA_PE_MATA311.prw
+++ b/FATURAMENTO/Ponto de Entrada/CASACHINA_PE_MATA311.prw
@@ -58,7 +58,7 @@ user function MATA311()
 			//apos a gravação, dentro da transação
 		case cIdPonto $ "MODELCOMMITTTS"
 			
-			If !IsInCallStack('A311Efetiv')
+			If !IsInCallStack('A311Efetiv') .And. !IsInCallStack('U_TRFFATAUT') .And. !IsInCallStack('U_TRFFATJOB')
 
 				oObjCyberLog := TCyberlogIntegracao():New()
 


### PR DESCRIPTION
Ao executar o execauto da rotina MATA311 do processo de faturamento automatico estava entrando no metodo MODELCOMMITTTS e enviando a transferencia para para o cyberlog novamente.